### PR TITLE
ITSASU-1444: Turn recreateIndexes flag to false

### DIFF
--- a/app/repositories/LockoutMongoRepository.scala
+++ b/app/repositories/LockoutMongoRepository.scala
@@ -53,7 +53,7 @@ class LockoutMongoRepository @Inject()(val config: LockoutMongoRepositoryConfig)
     mongoComponent = config.mongoComponent,
     domainFormat = implicitly[Format[JsObject]],
     indexes = config.indexes,
-    replaceIndexes = true
+    replaceIndexes = false
   ) {
 
   def insert(document: JsObject): Future[InsertOneResult] = collection.insertOne(document).toFuture

--- a/app/repositories/SubscriptionDataRepository.scala
+++ b/app/repositories/SubscriptionDataRepository.scala
@@ -58,7 +58,7 @@ class SubscriptionDataRepository @Inject()(config: SubscriptionDataRepositoryCon
     mongoComponent = config.mongoComponent,
     domainFormat = implicitly[Format[JsObject]],
     indexes = config.indexes,
-    replaceIndexes = true
+    replaceIndexes = false
   ) {
 
   private val findOneAndUpdateOptions: FindOneAndUpdateOptions = new FindOneAndUpdateOptions().upsert(true)

--- a/app/repositories/ThrottlingRepository.scala
+++ b/app/repositories/ThrottlingRepository.scala
@@ -57,13 +57,12 @@ class ThrottlingRepositoryConfig @Inject()(val appConfig: AppConfig) {
 
 @Singleton
 class ThrottlingRepository @Inject()(config: ThrottlingRepositoryConfig, instantProvider: InstantProvider)(implicit ec: ExecutionContext)
-
   extends PlayMongoRepository[JsObject](
     collectionName = "throttling",
     mongoComponent = config.mongoComponent,
     domainFormat = implicitly[Format[JsObject]],
     indexes = config.indexes,
-    replaceIndexes = true
+    replaceIndexes = false
   ) {
 
   private def timecode(time: Long) = time / 60000

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -29,7 +29,7 @@ object AppDependencies {
 
   private val scalaJVersion = "2.4.2"
 
-  private val hmrcMongoVersion = "0.64.0"
+  private val hmrcMongoVersion = "0.68.0"
 
   private val wiremockVersion = "2.32.0"
 


### PR DESCRIPTION
- Turn recreateIndexes flag to false to complete the migration from simple-reactivemongo to hmrc-mongo
