### PR TITLE
ITSASU-5207-HotFix

### DIFF
--- a/app/connectors/ItsaIncomeSourceConnector.scala
+++ b/app/connectors/ItsaIncomeSourceConnector.scala
@@ -18,6 +18,8 @@ package connectors
 
 import com.typesafe.config.Config
 import config.AppConfig
+import config.featureswitch.FeatureSwitch.SubmissionAuditUpdate
+import config.featureswitch.FeatureSwitching
 import connectors.hip.BaseHIPConnector
 import models.monitoring.SignUpAudit
 import models.subscription.CreateIncomeSourcesModel
@@ -26,7 +28,7 @@ import parsers.ITSAIncomeSourceParser.*
 import play.api.libs.json.Json
 import play.api.mvc.Request
 import services.monitoring.AuditService
-import services.monitoring.CreateIncomeSourcesAudit
+import models.monitoring.CreateIncomeSourcesAudit
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, Retries}
 
@@ -39,7 +41,7 @@ class ItsaIncomeSourceConnector @Inject()(val httpClient: HttpClientV2,
                                           val configuration: Config,
                                           val actorSystem: ActorSystem,
                                           auditService: AuditService)
-                                         (implicit val ec: ExecutionContext) extends BaseHIPConnector with Retries {
+                                         (implicit val ec: ExecutionContext) extends BaseHIPConnector with Retries with FeatureSwitching {
 
   private def itsaIncomeSourceUrl =
     "/etmp/RESTAdapter/itsa/taxpayer/income-source"
@@ -50,14 +52,18 @@ class ItsaIncomeSourceConnector @Inject()(val httpClient: HttpClientV2,
                          (implicit hc: HeaderCarrier, request: Request[_]): Future[PostITSAIncomeSourceResponse] = {
     auditService.extendedAudit(SignUpAudit(agentReferenceNumber, createIncomeSources, appConfig.getHipAuthToken))
 
-    updateETMP(mtdbsaRef, createIncomeSources) map { result =>
-      auditService.extendedAudit(CreateIncomeSourcesAudit(
-        agentReferenceNumber   = agentReferenceNumber,
-        nino                   = createIncomeSources.nino,
-        mtdItsaReferenceNumber = mtdbsaRef,
-        result                 = result.map(_ => ())
-      ))
-      result
+    updateETMP(mtdbsaRef, createIncomeSources) flatMap { result =>
+      if (isEnabled(SubmissionAuditUpdate)) {
+        auditService.extendedAudit(CreateIncomeSourcesAudit(
+          agentReferenceNumber   = agentReferenceNumber,
+          nino                   = createIncomeSources.nino,
+          mtdItsaReferenceNumber = mtdbsaRef,
+          isSuccess              = result.isRight,
+          errorReason            = result.left.toOption.map(_.reason)
+        )) map { _ => result }
+      } else {
+        Future.successful(result)
+      }
     }
   }
 

--- a/app/models/monitoring/CreateIncomeSourcesAudit.scala
+++ b/app/models/monitoring/CreateIncomeSourcesAudit.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package services.monitoring
+package models.monitoring
 
 import models.subscription.business.CreateIncomeSourceErrorModel
 import play.api.libs.json.{JsValue, Json}
@@ -24,25 +24,33 @@ import utils.JsonUtils.JsObjectUtil
 case class CreateIncomeSourcesAudit(agentReferenceNumber: Option[String],
                                     nino: String,
                                     mtdItsaReferenceNumber: String,
-                                    result: Either[CreateIncomeSourceErrorModel, Unit]
-                                   ) extends ExtendedAuditModel {
+                                    isSuccess: Boolean,
+                                    errorReason: Option[String]) extends ExtendedAuditModel {
 
   val userType: String = if (agentReferenceNumber.isDefined) "agent" else "individual"
 
   override val auditType: String = "ITSACreateIncomeSourcesOutcome"
-  override val transactionName: Option[String] = Some("itsa-create-income-sources-outcome")
+  override val transactionName: Option[String] = None
 
   override val detail: JsValue = {
     val base = Json.obj(
       "userType"               -> userType,
       "nino"                   -> nino,
       "mtdItsaReferenceNumber" -> mtdItsaReferenceNumber,
-      "incomeSourcesCreate"    -> (if (result.isRight) "Success" else "Failure")
+      "incomeSourcesCreate"    -> (if (isSuccess) "Success" else "Failure")
     ) ++ agentReferenceNumber.map(arn => Json.obj("agentReferenceNumber" -> arn))
 
-    result match {
-      case Left(error) => base ++ Json.obj("errorReason" -> error.reason)
-      case Right(_)    => base
+    errorReason match {
+      case Some(reason) => base ++ Json.obj("errorReason" -> CreateIncomeSourcesAudit.sanitiseErrorReason(reason))
+      case None         => base
     }
+  }
+}
+
+object CreateIncomeSourcesAudit {
+  private[monitoring] def sanitiseErrorReason(reason: String): String = {
+    val statusPrefix = "Status: "
+    val statusIndex = reason.indexOf(statusPrefix)
+    if (statusIndex >= 0) reason.substring(statusIndex).trim else reason
   }
 }

--- a/it/test/connectors/ItsaIncomeSourceConnectorISpec.scala
+++ b/it/test/connectors/ItsaIncomeSourceConnectorISpec.scala
@@ -18,6 +18,8 @@ package connectors
 
 import helpers.IntegrationTestConstants.{testArn, testCreateIncomeFailureBody, testCreateIncomeSources, testMtdbsaRef}
 import helpers.WiremockHelper.StubResponse
+import config.featureswitch.FeatureSwitch.SubmissionAuditUpdate
+import config.featureswitch.FeatureSwitching
 import helpers.servicemocks.{AuditStub, CreateIncomeSourceStub}
 import helpers.{ComponentSpecBase, WiremockHelper}
 import models.DateModel
@@ -27,17 +29,23 @@ import play.api.http.Status.{CREATED, FORBIDDEN, INTERNAL_SERVER_ERROR, UNPROCES
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Request
 import play.api.test.FakeRequest
+import config.MicroserviceAppConfig
 import utils.TestConstants.testCreateIncomeSuccessBody
 
-class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase {
+class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase with FeatureSwitching {
 
   private lazy val connector: ItsaIncomeSourceConnector = app.injector.instanceOf[ItsaIncomeSourceConnector]
+  val appConfig: MicroserviceAppConfig = app.injector.instanceOf[MicroserviceAppConfig]
   implicit val request: Request[_] = FakeRequest()
 
   override def overriddenConfig(): Map[String, String] = Map(
-    "auditing.enabled" -> "true",
-    "feature-switch.submission-audit-update" -> "true"
+    "auditing.enabled" -> "true"
   )
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    disable(SubmissionAuditUpdate)
+  }
 
   "createIncomeSources" must {
     "submit the country code if specified and GB if not" in {
@@ -71,7 +79,22 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase {
     }
 
     s"return a successful response when receiving a $CREATED response" in {
+      CreateIncomeSourceStub.stubItsaIncomeSource(
+        expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
+      )(status = CREATED, body = testCreateIncomeSuccessBody)
 
+      val result = connector.createIncomeSources(
+        agentReferenceNumber = Some(testArn),
+        mtdbsaRef = testMtdbsaRef,
+        createIncomeSources = testCreateIncomeSources
+      )
+
+      result.futureValue shouldBe Right(CreateIncomeSourceSuccessModel())
+      AuditStub.verifyAudit()
+    }
+
+    s"return a successful response when receiving a $CREATED response and SubmissionAuditUpdate is enabled" in {
+      enable(SubmissionAuditUpdate)
       CreateIncomeSourceStub.stubItsaIncomeSource(
         expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
       )(status = CREATED, body = testCreateIncomeSuccessBody)
@@ -100,7 +123,28 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase {
       )
 
       result.futureValue shouldBe Right(CreateIncomeSourceSuccessModel())
+      WiremockHelper.verifyPost(
+        uri = s"/etmp/RESTAdapter/itsa/taxpayer/income-source",
+        times = 3
+      )
+      AuditStub.verifyAudit()
+    }
 
+    s"should retry 2 times and return a successful response when receiving a $FORBIDDEN status and SubmissionAuditUpdate is enabled" in {
+      enable(SubmissionAuditUpdate)
+      WiremockHelper.stubPostSequence(s"/etmp/RESTAdapter/itsa/taxpayer/income-source")(
+        StubResponse(FORBIDDEN),
+        StubResponse(FORBIDDEN),
+        StubResponse(CREATED)
+      )
+
+      val result = connector.createIncomeSources(
+        agentReferenceNumber = Some(testArn),
+        mtdbsaRef = testMtdbsaRef,
+        createIncomeSources = testCreateIncomeSources
+      )
+
+      result.futureValue shouldBe Right(CreateIncomeSourceSuccessModel())
       WiremockHelper.verifyPost(
         uri = s"/etmp/RESTAdapter/itsa/taxpayer/income-source",
         times = 3
@@ -125,9 +169,45 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase {
             status = UNPROCESSABLE_ENTITY,
             reason = s"API #5265: Create income sources, Status: $UNPROCESSABLE_ENTITY, Code: 000, Reason: error text"
           ))
+          AuditStub.verifyAudit()
+        }
+        "has a valid error json and SubmissionAuditUpdate is enabled" in {
+          enable(SubmissionAuditUpdate)
+          CreateIncomeSourceStub.stubItsaIncomeSource(
+            expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
+          )(status = UNPROCESSABLE_ENTITY, body = errorsJson)
+
+          val result = connector.createIncomeSources(
+            agentReferenceNumber = Some(testArn),
+            mtdbsaRef = testMtdbsaRef,
+            createIncomeSources = testCreateIncomeSources
+          )
+
+          result.futureValue shouldBe Left(CreateIncomeSourceErrorModel(
+            status = UNPROCESSABLE_ENTITY,
+            reason = s"API #5265: Create income sources, Status: $UNPROCESSABLE_ENTITY, Code: 000, Reason: error text"
+          ))
           AuditStub.verifyAuditCount(2)
         }
         "has an invalid error json" in {
+          CreateIncomeSourceStub.stubItsaIncomeSource(
+            expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
+          )(status = UNPROCESSABLE_ENTITY, body = Json.obj())
+
+          val result = connector.createIncomeSources(
+            agentReferenceNumber = Some(testArn),
+            mtdbsaRef = testMtdbsaRef,
+            createIncomeSources = testCreateIncomeSources
+          )
+
+          result.futureValue shouldBe Left(CreateIncomeSourceErrorModel(
+            status = UNPROCESSABLE_ENTITY,
+            reason = s"API #5265: Create income sources, Status: $UNPROCESSABLE_ENTITY, Message: Failure parsing json response"
+          ))
+          AuditStub.verifyAudit()
+        }
+        "has an invalid error json and SubmissionAuditUpdate is enabled" in {
+          enable(SubmissionAuditUpdate)
           CreateIncomeSourceStub.stubItsaIncomeSource(
             expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
           )(status = UNPROCESSABLE_ENTITY, body = Json.obj())
@@ -162,6 +242,25 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase {
         status = INTERNAL_SERVER_ERROR,
         reason = s"API #5265: Create income sources, Status: $INTERNAL_SERVER_ERROR, Message: Unexpected status received"
       ))
+      AuditStub.verifyAudit()
+    }
+
+    s"return a failure response when receiving a non-$CREATED response and SubmissionAuditUpdate is enabled" in {
+      enable(SubmissionAuditUpdate)
+      CreateIncomeSourceStub.stubItsaIncomeSource(
+        expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
+      )(status = INTERNAL_SERVER_ERROR, body = testCreateIncomeFailureBody)
+
+      val result = connector.createIncomeSources(
+        agentReferenceNumber = Some(testArn),
+        mtdbsaRef = testMtdbsaRef,
+        createIncomeSources = testCreateIncomeSources
+      )
+
+      result.futureValue shouldBe Left(CreateIncomeSourceErrorModel(
+        status = INTERNAL_SERVER_ERROR,
+        reason = s"API #5265: Create income sources, Status: $INTERNAL_SERVER_ERROR, Message: Unexpected status received"
+      ))
       AuditStub.verifyAuditCount(2)
     }
   }
@@ -169,5 +268,4 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase {
   lazy val errorsJson: JsObject = Json.obj(
     "errors" -> Json.obj("code" -> "000", "text" -> "error text", "processingDate" -> "")
   )
-
 }

--- a/it/test/connectors/ItsaIncomeSourceConnectorISpec.scala
+++ b/it/test/connectors/ItsaIncomeSourceConnectorISpec.scala
@@ -78,35 +78,23 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase with FeatureSwitc
       }
     }
 
-    s"return a successful response when receiving a $CREATED response" in {
-      CreateIncomeSourceStub.stubItsaIncomeSource(
-        expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
-      )(status = CREATED, body = testCreateIncomeSuccessBody)
+    Seq(false, true).foreach { submissionAuditUpdateEnabled =>
+      s"return a successful response when receiving a $CREATED response and SubmissionAuditUpdate is $submissionAuditUpdateEnabled" in {
+        if (submissionAuditUpdateEnabled) enable(SubmissionAuditUpdate)
 
-      val result = connector.createIncomeSources(
-        agentReferenceNumber = Some(testArn),
-        mtdbsaRef = testMtdbsaRef,
-        createIncomeSources = testCreateIncomeSources
-      )
+        CreateIncomeSourceStub.stubItsaIncomeSource(
+          expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
+        )(status = CREATED, body = testCreateIncomeSuccessBody)
 
-      result.futureValue shouldBe Right(CreateIncomeSourceSuccessModel())
-      AuditStub.verifyAudit()
-    }
+        val result = connector.createIncomeSources(
+          agentReferenceNumber = Some(testArn),
+          mtdbsaRef = testMtdbsaRef,
+          createIncomeSources = testCreateIncomeSources
+        )
 
-    s"return a successful response when receiving a $CREATED response and SubmissionAuditUpdate is enabled" in {
-      enable(SubmissionAuditUpdate)
-      CreateIncomeSourceStub.stubItsaIncomeSource(
-        expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
-      )(status = CREATED, body = testCreateIncomeSuccessBody)
-
-      val result = connector.createIncomeSources(
-        agentReferenceNumber = Some(testArn),
-        mtdbsaRef = testMtdbsaRef,
-        createIncomeSources = testCreateIncomeSources
-      )
-
-      result.futureValue shouldBe Right(CreateIncomeSourceSuccessModel())
-      AuditStub.verifyAuditCount(2)
+        result.futureValue shouldBe Right(CreateIncomeSourceSuccessModel())
+        AuditStub.verifyAuditCount(1 + (if (submissionAuditUpdateEnabled) 1 else 0))
+      }
     }
 
     s"should retry 2 times and return a successful response when receiving a $FORBIDDEN status" in {
@@ -130,28 +118,6 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase with FeatureSwitc
       AuditStub.verifyAudit()
     }
 
-    s"should retry 2 times and return a successful response when receiving a $FORBIDDEN status and SubmissionAuditUpdate is enabled" in {
-      enable(SubmissionAuditUpdate)
-      WiremockHelper.stubPostSequence(s"/etmp/RESTAdapter/itsa/taxpayer/income-source")(
-        StubResponse(FORBIDDEN),
-        StubResponse(FORBIDDEN),
-        StubResponse(CREATED)
-      )
-
-      val result = connector.createIncomeSources(
-        agentReferenceNumber = Some(testArn),
-        mtdbsaRef = testMtdbsaRef,
-        createIncomeSources = testCreateIncomeSources
-      )
-
-      result.futureValue shouldBe Right(CreateIncomeSourceSuccessModel())
-      WiremockHelper.verifyPost(
-        uri = s"/etmp/RESTAdapter/itsa/taxpayer/income-source",
-        times = 3
-      )
-      AuditStub.verifyAuditCount(2)
-    }
-
     s"return a failure response" when {
       s"receiving a $UNPROCESSABLE_ENTITY status response" which {
         "has a valid error json" in {
@@ -171,24 +137,7 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase with FeatureSwitc
           ))
           AuditStub.verifyAudit()
         }
-        "has a valid error json and SubmissionAuditUpdate is enabled" in {
-          enable(SubmissionAuditUpdate)
-          CreateIncomeSourceStub.stubItsaIncomeSource(
-            expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
-          )(status = UNPROCESSABLE_ENTITY, body = errorsJson)
 
-          val result = connector.createIncomeSources(
-            agentReferenceNumber = Some(testArn),
-            mtdbsaRef = testMtdbsaRef,
-            createIncomeSources = testCreateIncomeSources
-          )
-
-          result.futureValue shouldBe Left(CreateIncomeSourceErrorModel(
-            status = UNPROCESSABLE_ENTITY,
-            reason = s"API #5265: Create income sources, Status: $UNPROCESSABLE_ENTITY, Code: 000, Reason: error text"
-          ))
-          AuditStub.verifyAuditCount(2)
-        }
         "has an invalid error json" in {
           CreateIncomeSourceStub.stubItsaIncomeSource(
             expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
@@ -205,24 +154,6 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase with FeatureSwitc
             reason = s"API #5265: Create income sources, Status: $UNPROCESSABLE_ENTITY, Message: Failure parsing json response"
           ))
           AuditStub.verifyAudit()
-        }
-        "has an invalid error json and SubmissionAuditUpdate is enabled" in {
-          enable(SubmissionAuditUpdate)
-          CreateIncomeSourceStub.stubItsaIncomeSource(
-            expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
-          )(status = UNPROCESSABLE_ENTITY, body = Json.obj())
-
-          val result = connector.createIncomeSources(
-            agentReferenceNumber = Some(testArn),
-            mtdbsaRef = testMtdbsaRef,
-            createIncomeSources = testCreateIncomeSources
-          )
-
-          result.futureValue shouldBe Left(CreateIncomeSourceErrorModel(
-            status = UNPROCESSABLE_ENTITY,
-            reason = s"API #5265: Create income sources, Status: $UNPROCESSABLE_ENTITY, Message: Failure parsing json response"
-          ))
-          AuditStub.verifyAuditCount(2)
         }
       }
     }
@@ -243,25 +174,6 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase with FeatureSwitc
         reason = s"API #5265: Create income sources, Status: $INTERNAL_SERVER_ERROR, Message: Unexpected status received"
       ))
       AuditStub.verifyAudit()
-    }
-
-    s"return a failure response when receiving a non-$CREATED response and SubmissionAuditUpdate is enabled" in {
-      enable(SubmissionAuditUpdate)
-      CreateIncomeSourceStub.stubItsaIncomeSource(
-        expectedBody = Json.toJson(testCreateIncomeSources)(CreateIncomeSourcesModel.hipWrites(testMtdbsaRef))
-      )(status = INTERNAL_SERVER_ERROR, body = testCreateIncomeFailureBody)
-
-      val result = connector.createIncomeSources(
-        agentReferenceNumber = Some(testArn),
-        mtdbsaRef = testMtdbsaRef,
-        createIncomeSources = testCreateIncomeSources
-      )
-
-      result.futureValue shouldBe Left(CreateIncomeSourceErrorModel(
-        status = INTERNAL_SERVER_ERROR,
-        reason = s"API #5265: Create income sources, Status: $INTERNAL_SERVER_ERROR, Message: Unexpected status received"
-      ))
-      AuditStub.verifyAuditCount(2)
     }
   }
 

--- a/it/test/connectors/ItsaIncomeSourceConnectorISpec.scala
+++ b/it/test/connectors/ItsaIncomeSourceConnectorISpec.scala
@@ -35,7 +35,8 @@ class ItsaIncomeSourceConnectorISpec extends ComponentSpecBase {
   implicit val request: Request[_] = FakeRequest()
 
   override def overriddenConfig(): Map[String, String] = Map(
-    "auditing.enabled" -> "true"
+    "auditing.enabled" -> "true",
+    "feature-switch.submission-audit-update" -> "true"
   )
 
   "createIncomeSources" must {

--- a/test/models/monitoring/CreateIncomeSourcesAuditSpec.scala
+++ b/test/models/monitoring/CreateIncomeSourcesAuditSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.monitoring
+
+import common.CommonSpec
+
+class CreateIncomeSourcesAuditSpec extends CommonSpec {
+
+  "CreateIncomeSourcesAudit.sanitiseErrorReason" should {
+    "strip parser metadata from a coded HIP error" in {
+      val rawReason = "API #5265: Create income sources, Status: 422, Code: 999, Reason: Request could not be processed"
+
+      CreateIncomeSourcesAudit.sanitiseErrorReason(rawReason) shouldBe "Status: 422, Code: 999, Reason: Request could not be processed"
+    }
+  }
+
+  "CreateIncomeSourcesAudit.detail" should {
+    "include the sanitised error reason on failure" in {
+      val audit = CreateIncomeSourcesAudit(
+        agentReferenceNumber   = None,
+        nino                   = "AA123456A",
+        mtdItsaReferenceNumber = "XAIT000000000",
+        isSuccess              = false,
+        errorReason            = Some("API #5265: Create income sources, Status: 422, Code: 999, Reason: Request could not be processed")
+      )
+
+      (audit.detail \ "errorReason").as[String] shouldBe "Status: 422, Code: 999, Reason: Request could not be processed"
+    }
+  }
+}
+


### PR DESCRIPTION
**Follow-up changes from review comments:**

- Decoupled `SignUpAudit` from `updateETMP` by removing the `flatMap` chain — `SignUpAudit` now fires independently so a failed audit can never block the API call
- Replaced `result.map(_ => ())` with `isSuccess: Boolean` and `errorReason: Option[String]` parameters, as `CreateIncomeSourceSuccessModel` is empty so mapping to `Unit` was unnecessary
- Removed `transactionName` from the model as it is not required for new audits
- Added `sanitiseErrorReason` to strip parser metadata from error strings
- Moved model from `services/monitoring/` to `models/monitoring/` for consistency with other audit models
- Gated the audit behind `SubmissionAuditUpdate` feature switch in the connector rather than the model, as there is no legacy audit to fall back to when disabled
- Added `CreateIncomeSourcesAuditSpec`
- Enabled featureswitch in `ItsaIncomeSourceConnectorISpec`