### PR TITLE
ITSASU-5301

### DIFF
--- a/app/connectors/hip/HipPrePopConnector.scala
+++ b/app/connectors/hip/HipPrePopConnector.scala
@@ -16,27 +16,42 @@
 
 package connectors.hip
 
+import com.typesafe.config.Config
 import config.AppConfig
+import connectors.ConnectorRetries
+import models.ErrorModel
 import models.hip.SelfEmpHolder
 import parsers.hip.HipPrePopParser.*
 import uk.gov.hmrc.http.HeaderCarrier
+import org.apache.pekko.actor.ActorSystem
+import play.api.http.Status.{BAD_GATEWAY, INTERNAL_SERVER_ERROR, SERVICE_UNAVAILABLE, TOO_MANY_REQUESTS}
 import uk.gov.hmrc.http.client.HttpClientV2
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class HipPrePopConnector @Inject()(val httpClient: HttpClientV2, val appConfig: AppConfig)
-                                  (implicit val ec: ExecutionContext) extends BaseHIPConnector {
+class HipPrePopConnector @Inject()(val httpClient: HttpClientV2,
+                                   val appConfig: AppConfig,
+                                   val configuration: Config,
+                                   val actorSystem: ActorSystem)
+                                  (implicit val ec: ExecutionContext) extends BaseHIPConnector with ConnectorRetries {
 
-  def getHipPrePopData(
-                        nino: String
-                      )(implicit hc: HeaderCarrier): Future[GetHipPrePopResponse] = {
-    super.get[SelfEmpHolder](
-      uri = hipPrePopUrl(nino),
-      parser = GetHipPrePopResponseHttpReads
-    )
-  }
+  private val apiNumber = GetHipPrePopResponseHttpReads.apiNumber
+  private val apiName = GetHipPrePopResponseHttpReads.apiName
+
+  def getHipPrePopData(nino: String)(implicit hc: HeaderCarrier): Future[GetHipPrePopResponse] =
+    retryFor[GetHipPrePopResponse](apiNumber, apiName) {
+      case Left(ErrorModel(TOO_MANY_REQUESTS, _, _)) => true
+      case Left(ErrorModel(BAD_GATEWAY, _, _)) => true
+      case Left(ErrorModel(SERVICE_UNAVAILABLE, _, _)) => true
+      case Left(ErrorModel(INTERNAL_SERVER_ERROR, _, _)) => true
+    } {
+      super.get[SelfEmpHolder](
+        uri = hipPrePopUrl(nino),
+        parser = GetHipPrePopResponseHttpReads
+      )
+    }
 
   private def hipPrePopUrl(nino: String) =
     s"/cesa/prepopulation/businessdata/$nino"

--- a/app/controllers/PrePopController.scala
+++ b/app/controllers/PrePopController.scala
@@ -53,7 +53,8 @@ class PrePopController @Inject()(authService: AuthService,
           ))
           Ok(Json.toJson(prePopData))
         case Left(error) =>
-          InternalServerError
+          logger.error(s"[PrePopController][prePop] - Failed to retrieve pre-pop data for nino: $nino. Error: $error")
+          Ok(Json.toJson(PrePopData(selfEmployment = None)))
       }
     }
   }

--- a/app/parsers/hip/HipPrePopParser.scala
+++ b/app/parsers/hip/HipPrePopParser.scala
@@ -19,7 +19,7 @@ package parsers.hip
 import models.ErrorModel
 import models.hip.SelfEmpHolder
 import play.api.Logging
-import play.api.http.Status.{BAD_GATEWAY, NOT_FOUND, OK, SERVICE_UNAVAILABLE}
+import play.api.http.Status.{NOT_FOUND, OK}
 import play.api.libs.json.{JsError, JsSuccess, JsValue}
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
 
@@ -35,7 +35,7 @@ object HipPrePopParser extends Logging {
       (_: String, _: String, response: HttpResponse) => {
         response.status match {
           case OK => handleOkResponse(response.json, correlationId)
-          case NOT_FOUND | SERVICE_UNAVAILABLE | BAD_GATEWAY => Right(SelfEmpHolder(None))
+          case NOT_FOUND => Right(SelfEmpHolder(None))
           case status => handleOtherResponse(status, correlationId)
         }
       }

--- a/it/test/connectors/hip/HipPrePopConnectorISpec.scala
+++ b/it/test/connectors/hip/HipPrePopConnectorISpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.hip
+
+import helpers.WiremockHelper.StubResponse
+import helpers.{ComponentSpecBase, WiremockHelper}
+import models.hip.{SelfEmp, SelfEmpHolder}
+import play.api.http.Status.{BAD_GATEWAY, INTERNAL_SERVER_ERROR, OK, SERVICE_UNAVAILABLE, TOO_MANY_REQUESTS, BAD_REQUEST, NOT_FOUND}
+import play.api.libs.json.Json
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+
+class HipPrePopConnectorISpec extends ComponentSpecBase {
+
+  private lazy val connector: HipPrePopConnector = app.injector.instanceOf[HipPrePopConnector]
+
+  val testNino: String = "test-nino"
+  val url: String = s"/cesa/prepopulation/businessdata/$testNino"
+
+  val testSelfEmpHolder: SelfEmpHolder = SelfEmpHolder(
+    selfEmp = Some(Seq(SelfEmp(
+      businessName = Some("ABC Plumbers"),
+      businessDescription = Some("Plumber"),
+      businessAddressFirstLine = Some("1 Hazel Court"),
+      businessAddressPostcode = Some("AB12 3CD"),
+      dateBusinessStarted = Some("2011-08-14")
+    )))
+  )
+
+  "getHipPrePopData" when {
+
+    "retry" should {
+      Seq(BAD_GATEWAY, TOO_MANY_REQUESTS, SERVICE_UNAVAILABLE, INTERNAL_SERVER_ERROR).foreach { status =>
+        s"For a return status of $status" in {
+          val nino = s"test-nino-$status"
+          val statusUrl = s"/cesa/prepopulation/businessdata/$nino"
+
+          WiremockHelper.stubGetSequence(statusUrl)(
+            StubResponse(status),
+            StubResponse(status),
+            StubResponse(OK, Json.toJson(testSelfEmpHolder))
+          )
+
+          val result = await(connector.getHipPrePopData(nino))
+
+          result shouldBe Right(testSelfEmpHolder)
+
+          WiremockHelper.verifyGet(uri = statusUrl, times = 3)
+        }
+      }
+    }
+
+    "retries are exhausted" should {
+      "return a Left after repeated failures" in {
+        val nino = "test-nino-exhausted"
+        val exhaustedUrl = s"/cesa/prepopulation/businessdata/$nino"
+
+        WiremockHelper.stubGetSequence(exhaustedUrl)(
+          StubResponse(INTERNAL_SERVER_ERROR),
+          StubResponse(INTERNAL_SERVER_ERROR),
+          StubResponse(INTERNAL_SERVER_ERROR),
+          StubResponse(INTERNAL_SERVER_ERROR)
+        )
+
+        val result = await(connector.getHipPrePopData(nino))
+
+        result.isLeft shouldBe true
+
+        WiremockHelper.verifyGet(uri = exhaustedUrl, times = 4)
+      }
+    }
+  }
+
+  "an unrecognised status is returned" should {
+    "not retry and return a Left immediately" in {
+      val nino = "test-nino-no-retry"
+      val noRetryUrl = s"/cesa/prepopulation/businessdata/$nino"
+
+      WiremockHelper.stubGet(noRetryUrl, BAD_REQUEST, Json.stringify(Json.obj()))
+
+      val result = await(connector.getHipPrePopData(nino))
+
+      result.isLeft shouldBe true
+
+      WiremockHelper.verifyGet(uri = noRetryUrl, times = 1)
+    }
+  }
+
+  "a NOT_FOUND response is returned" should {
+    "return an empty result without retrying" in {
+      val nino = "test-nino-not-found"
+      val notFoundUrl = s"/cesa/prepopulation/businessdata/$nino"
+
+      WiremockHelper.stubGet(notFoundUrl, NOT_FOUND, Json.stringify(Json.obj()))
+
+      val result = await(connector.getHipPrePopData(nino))
+
+      result shouldBe Right(SelfEmpHolder(None))
+
+      WiremockHelper.verifyGet(uri = notFoundUrl, times = 1)
+    }
+  }
+}

--- a/it/test/controllers/PrePopControllerISpec.scala
+++ b/it/test/controllers/PrePopControllerISpec.scala
@@ -96,7 +96,7 @@ class PrePopControllerISpec extends ComponentSpecBase with FeatureSwitching {
         )
 
       }
-      "there was an error returned from the pre-pop API" in {
+      "no data returned from the pre-pop API" in {
         AuthStub.stubAuth(OK)
 
         PrePopStub.stubHipPrePop(testNino)(
@@ -107,7 +107,7 @@ class PrePopControllerISpec extends ComponentSpecBase with FeatureSwitching {
         val res = IncomeTaxSubscription.getPrePop(testNino)
 
         res should have(
-          httpStatus(INTERNAL_SERVER_ERROR)
+          httpStatus(OK)
         )
       }
     }

--- a/test/connectors/hip/HipPrePopConnectorSpec.scala
+++ b/test/connectors/hip/HipPrePopConnectorSpec.scala
@@ -22,7 +22,7 @@ import models.ErrorModel
 import models.hip.{SelfEmp, SelfEmpHolder}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import parsers.hip.HipPrePopParser.GetHipPrePopResponseHttpReads
-import play.api.http.Status.{BAD_GATEWAY, INTERNAL_SERVER_ERROR, OK}
+import play.api.http.Status.{BAD_GATEWAY, INTERNAL_SERVER_ERROR, OK, SERVICE_UNAVAILABLE}
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.HttpResponse
 
@@ -75,13 +75,17 @@ class HipPrePopConnectorSpec extends CommonSpec with MockHttp with GuiceOneAppPe
       }
 
       "the HIP API #5646 returns BAD_GATEWAY" in {
-        val response = HttpResponse(
-          BAD_GATEWAY,
-          Json.obj().toString
-        )
+        val response = HttpResponse(BAD_GATEWAY, Json.obj().toString)
 
         GetHipPrePopResponseHttpReads.httpReads(testCorrelationId).read("", "", response) shouldBe
-          Right(SelfEmpHolder(None))
+          Left(ErrorModel(BAD_GATEWAY, s"API #5646: Business Data, Status: 502, Message: Unexpected status returned"))
+      }
+
+      "the HIP API #5646 returns SERVICE_UNAVAILABLE" in {
+        val response = HttpResponse(SERVICE_UNAVAILABLE, Json.obj().toString)
+
+        GetHipPrePopResponseHttpReads.httpReads(testCorrelationId).read("", "", response) shouldBe
+          Left(ErrorModel(SERVICE_UNAVAILABLE, s"API #5646: Business Data, Status: 503, Message: Unexpected status returned"))
       }
     }
   }

--- a/test/parsers/hip/HipPrePopParserSpec.scala
+++ b/test/parsers/hip/HipPrePopParserSpec.scala
@@ -76,7 +76,9 @@ class HipPrePopParserSpec extends CommonSpec {
 
     "a SERVICE_UNAVAILABLE (503) status is returned" should {
       "return an empty prepop data set" in {
-        read(SERVICE_UNAVAILABLE) shouldBe Right(SelfEmpHolder(None))
+        read(SERVICE_UNAVAILABLE) shouldBe Left(ErrorModel(
+          SERVICE_UNAVAILABLE, s"API #5646: Business Data, Status: 503, Message: Unexpected status returned"
+        ))
       }
     }
 


### PR DESCRIPTION
### Summary
Adds retry handling for API #5646 (Pre-pop business data) per Kibana error breakdown (502/503/429/500), and ensures the journey continues gracefully if retries are exhausted.

### Changes

1. **HipPrePopConnector** — Added `INTERNAL_SERVER_ERROR` (500) to retry conditions, alongside existing 429/502/503.

2. **HipPrePopParser** — Fixed `BAD_GATEWAY` (502) and `SERVICE_UNAVAILABLE` (503) incorrectly resolving to `Right(SelfEmpHolder(None))` instead of `Left`, meaning they never reached retry logic. Only `NOT_FOUND` now resolves to empty data; 502/503 fall through to error handling as intended.

3. **PrePopController** — Changed `Left(error)` handling to return `OK` with empty `PrePopData` instead of `InternalServerError`, so a failed/exhausted pre-pop call no longer blocks the journey.

4. **PrePopControllerISpec** — Amended test to cover the PrePopController returning OK if data is empty.

5. **HipPrePopConnectorISpec** *(new)* — Added integration tests covering retry behaviour for `TOO_MANY_REQUESTS`, `BAD_GATEWAY`, `SERVICE_UNAVAILABLE`, `INTERNAL_SERVER_ERROR`, plus a retries-exhausted scenario.

6. **HipPrePopParserSpec** — Amended test: a `BAD_GATEWAY` (502) status is returned to `Left` error.

7. **HipPrePopConnectorSpec.scala** — Amended test: a `SERVICE_UNAVAILABLE` (503) status is returned to `Left` error.